### PR TITLE
Bug fixes for invalid file paths

### DIFF
--- a/conf/rs_conf.yml
+++ b/conf/rs_conf.yml
@@ -3,7 +3,7 @@ redstack_version: "1.0.0"
 
 # Directories
 deployment_directory_base: "/var/stacker/deployments"
-installation_directory: "/opt/redstack/REDstack-oss2"
+installation_directory: "/opt/redstack/REDstack"
 cookbook_directory: "/opt/redstack/cookbooks"
 
 # Logging

--- a/redstack/blueprints.py
+++ b/redstack/blueprints.py
@@ -20,7 +20,7 @@ class BlueprintBuilder:
         self.stack_type = 'HDP'
 
         self.blueprint_directory = os.path.join(self.deploy.installation_directory,
-                                                'conf', 'blueprints', self.stack_type)
+                                                'conf', 'blueprints', self.stack_type.lower())
 
     def create_all(self):
         # type: () -> None

--- a/scripts/run_redstack.sh
+++ b/scripts/run_redstack.sh
@@ -1,1 +1,1 @@
-python /opt/redstack/REDstack/redstack/install.py --config /opt/redstack/REDstack/config/rs-conf.yml
+python /opt/redstack/REDstack/redstack/install.py --config /opt/redstack/REDstack/conf/rs_conf.yml


### PR DESCRIPTION
A few of the file paths were not in agreement.

1. Fixed the paths and file names in the startup script.
2. blueprints.yml creates an invalid path to the blueprints file, it used "HDP" instead of "hdp"
3. rs_conf.yml had an invalid install directory compared to the Dockerfile. Went with Dockerfile's implementation.