### PR TITLE
Octal numbers in Python 3: 0400 --> 0o400

### DIFF
--- a/redstack/environment.py
+++ b/redstack/environment.py
@@ -54,7 +54,7 @@ class Environment:
             new_private_key = os.path.join(self.deploy.directory, self.deploy.key_name)
             shutil.copyfile(self.deploy.cluster.private_key, new_private_key)
             self.deploy.cluster.private_key = os.path.join(self.deploy.directory, new_private_key)
-            os.chmod(self.deploy.cluster.private_key, 0400)
+            os.chmod(self.deploy.cluster.private_key, 0o400)
 
         logger.info('Deploy directory: {0}'.format(self.deploy.directory))
 

--- a/redstack/openstack.py
+++ b/redstack/openstack.py
@@ -436,7 +436,7 @@ class Openstack:
         key_path = os.path.join(self.deploy.directory, self.deploy.name)
         with open(key_path, "w") as key_file:
             key_file.write(private_key)
-            os.chmod(key_path, 0400)
+            os.chmod(key_path, 0o400)
 
         logger.info("Created new Private Key file for Openstack deployment")
         return key_path


### PR DESCRIPTION
$ __python3 -c "0400"__  # syntax error  Octal numbers _must_ be written starting with __0o__ in Python 3.

[flake8](http://flake8.pycqa.org) testing of https://github.com/target/REDstack on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./redstack/environment.py:57:58: E999 SyntaxError: invalid token
            os.chmod(self.deploy.cluster.private_key, 0400)
                                                         ^
./redstack/openstack.py:439:35: E999 SyntaxError: invalid token
            os.chmod(key_path, 0400)
                                  ^
2     E999 SyntaxError: invalid token
2
```